### PR TITLE
revert: restore node16 runtime and pre-PR#4 dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   color: "red"
 description: "Deploy your NPM package using oddish directly from GitHub"
 runs:
-  using: "node20"
+  using: "node16"
   main: "dist/index.js"
 outputs:
   version:

--- a/dist/index.js
+++ b/dist/index.js
@@ -157475,7 +157475,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __nccwpck_require__(42186);
 const io = __nccwpck_require__(47351);
-const artifact_1 = __nccwpck_require__(79450);
 const github = __nccwpck_require__(95438);
 const child_process_1 = __nccwpck_require__(32081);
 const form_data_1 = __importDefault(__nccwpck_require__(64334));
@@ -157487,6 +157486,7 @@ const fs = __nccwpck_require__(57147);
 const os = __nccwpck_require__(22037);
 const child_process_2 = __nccwpck_require__(32081);
 const path_1 = __nccwpck_require__(71017);
+const artifact_1 = __nccwpck_require__(79450);
 const cleanupSteps = [];
 const commitHash = (0, child_process_2.execSync)("git rev-parse HEAD").toString().trim();
 function readPackageJson(workingDirectory) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
         "@actions/io": "1.1.2",
         "@aws-sdk/client-s3": "^3.352.0",
         "@types/git-rev-sync": "^2.0.0",
-        "@types/node": "^24.0.0",
+        "@types/node": "^14.17.6",
         "@types/node-fetch": "^2.5.12",
         "@types/semver": "^7.3.8",
         "@vercel/ncc": "^0.36.1",
         "git-rev-sync": "^3.0.2",
         "node-fetch": "^2.6.9",
         "semver": "^7.5.2",
-        "typescript": "^5.4.0"
+        "typescript": "^4.6.2"
       }
     },
     "node_modules/@actions/artifact": {
@@ -1861,13 +1861,9 @@
       "integrity": "sha512-qGYApbb0m8Ofy3pwYks+kYVIZQAN/cqNucJGbl5O5GpLw9JSzp74rkTWDhPv3brrJfJb5/ixtimLJpo4tfh2QA=="
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
+      "version": "14.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+      "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -3173,16 +3169,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/undici": {
@@ -3195,12 +3190,6 @@
       "engines": {
         "node": ">=14.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
@@ -4907,12 +4896,9 @@
       "integrity": "sha512-qGYApbb0m8Ofy3pwYks+kYVIZQAN/cqNucJGbl5O5GpLw9JSzp74rkTWDhPv3brrJfJb5/ixtimLJpo4tfh2QA=="
     },
     "@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-      "requires": {
-        "undici-types": "~7.16.0"
-      }
+      "version": "14.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+      "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -5857,9 +5843,9 @@
       }
     },
     "typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
     },
     "undici": {
       "version": "5.28.5",
@@ -5868,11 +5854,6 @@
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }
-    },
-    "undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "@actions/io": "1.1.2",
     "@aws-sdk/client-s3": "^3.352.0",
     "@types/git-rev-sync": "^2.0.0",
-    "@types/node": "^24.0.0",
+    "@types/node": "^14.17.6",
     "@types/node-fetch": "^2.5.12",
     "@types/semver": "^7.3.8",
     "@vercel/ncc": "^0.36.1",
     "git-rev-sync": "^3.0.2",
     "node-fetch": "^2.6.9",
     "semver": "^7.5.2",
-    "typescript": "^5.4.0"
+    "typescript": "^4.6.2"
   }
 }


### PR DESCRIPTION
Restaura `action.yml`, `package.json` y `package-lock.json` al estado previo a PR #4 (`node16`, `@types/node@^14.17.6`, `typescript@^4.6.2`). En `dist/index.js` se revierte únicamente el reordenamiento de imports que introdujo PR #4 (movimiento de `artifact_1` a su posición original), sin regenerar el bundle.

## Verificación

- `git diff` contra el commit pre-PR#4 (`914e7c5`) sobre `action.yml`, `package.json` y `package-lock.json` es vacío.
- En `dist/index.js` el bloque de imports vuelve al orden original.
- No se ejecutó `npm install` ni `npm run build`; el bundle existente sigue siendo funcionalmente equivalente.