### PR TITLE
feat: support npm Trusted Publishing (OIDC) auth

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -157621,18 +157621,34 @@ function writeRegistryToFile(registryUrl, fileLocation, alwaysAuth) {
             }
         });
     }
+    // Detect whether OIDC (npm Trusted Publishing) is available. GitHub Actions
+    // exposes ACTIONS_ID_TOKEN_REQUEST_URL only when the job grants
+    // `permissions: id-token: write`. When the caller did not provide an explicit
+    // NODE_AUTH_TOKEN but OIDC is available, we skip the _authToken line and the
+    // dummy env so npm can exchange the OIDC token for publish credentials.
+    // See: https://docs.npmjs.com/trusted-publishers
+    const hasExplicitToken = !!process.env.NODE_AUTH_TOKEN;
+    const hasOIDC = !!process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+    const useOIDC = !hasExplicitToken && hasOIDC;
     // Remove http: or https: from front of registry.
     const authString = registryUrl.replace(/(^\w+:|^)/, "") + ":_authToken=${NODE_AUTH_TOKEN}";
     const registryString = scope
         ? `${scope}:registry=${registryUrl}`
         : `registry=${registryUrl}`;
     const alwaysAuthString = `always-auth=${alwaysAuth}`;
-    newContents += `${authString}${os.EOL}${registryString}${os.EOL}${alwaysAuthString}`;
+    if (useOIDC) {
+        console.log(`  using OIDC (npm Trusted Publishing) — skipping _authToken in .npmrc`);
+        newContents += `${registryString}${os.EOL}${alwaysAuthString}`;
+    }
+    else {
+        newContents += `${authString}${os.EOL}${registryString}${os.EOL}${alwaysAuthString}`;
+    }
     console.log(`  writing: ${fileLocation}`);
     fs.writeFileSync(fileLocation, newContents);
     core.exportVariable("NPM_CONFIG_USERCONFIG", fileLocation);
-    // Export empty node_auth_token so npm doesn't complain about not being able to find it
-    if (!process.env.NODE_AUTH_TOKEN) {
+    // Export empty node_auth_token so npm doesn't complain about not being able
+    // to find it. Skip this when using OIDC so the dummy doesn't shadow OIDC auth.
+    if (!useOIDC && !process.env.NODE_AUTH_TOKEN) {
         core.exportVariable("NODE_AUTH_TOKEN", "XXXXX-XXXXX-XXXXX-XXXXX");
     }
 }
@@ -157741,8 +157757,8 @@ const run = async () => {
     }
     const alwaysAuth = core.getInput("always-auth") || "false";
     const mainBranchLatestTag = core.getBooleanInput("main-branch-latest-tag");
-    if (!process.env.NODE_AUTH_TOKEN) {
-        core.warning(`! warn: variable NODE_AUTH_TOKEN is not set`);
+    if (!process.env.NODE_AUTH_TOKEN && !process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+        core.warning(`! warn: variable NODE_AUTH_TOKEN is not set and OIDC is not available`);
     }
     if (process.env.NODE_AUTH_TOKEN || registryUrl) {
         configAuthentication(registryUrl, alwaysAuth, workingDirectory);

--- a/oddish.ts
+++ b/oddish.ts
@@ -178,6 +178,16 @@ function writeRegistryToFile(registryUrl: string, fileLocation: string, alwaysAu
     });
   }
 
+  // Detect whether OIDC (npm Trusted Publishing) is available. GitHub Actions
+  // exposes ACTIONS_ID_TOKEN_REQUEST_URL only when the job grants
+  // `permissions: id-token: write`. When the caller did not provide an explicit
+  // NODE_AUTH_TOKEN but OIDC is available, we skip the _authToken line and the
+  // dummy env so npm can exchange the OIDC token for publish credentials.
+  // See: https://docs.npmjs.com/trusted-publishers
+  const hasExplicitToken = !!process.env.NODE_AUTH_TOKEN;
+  const hasOIDC = !!process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const useOIDC = !hasExplicitToken && hasOIDC;
+
   // Remove http: or https: from front of registry.
   const authString: string =
     registryUrl.replace(/(^\w+:|^)/, "") + ":_authToken=${NODE_AUTH_TOKEN}";
@@ -185,12 +195,18 @@ function writeRegistryToFile(registryUrl: string, fileLocation: string, alwaysAu
     ? `${scope}:registry=${registryUrl}`
     : `registry=${registryUrl}`;
   const alwaysAuthString: string = `always-auth=${alwaysAuth}`;
-  newContents += `${authString}${os.EOL}${registryString}${os.EOL}${alwaysAuthString}`;
+  if (useOIDC) {
+    console.log(`  using OIDC (npm Trusted Publishing) — skipping _authToken in .npmrc`);
+    newContents += `${registryString}${os.EOL}${alwaysAuthString}`;
+  } else {
+    newContents += `${authString}${os.EOL}${registryString}${os.EOL}${alwaysAuthString}`;
+  }
   console.log(`  writing: ${fileLocation}`);
   fs.writeFileSync(fileLocation, newContents);
   core.exportVariable("NPM_CONFIG_USERCONFIG", fileLocation);
-  // Export empty node_auth_token so npm doesn't complain about not being able to find it
-  if (!process.env.NODE_AUTH_TOKEN) {
+  // Export empty node_auth_token so npm doesn't complain about not being able
+  // to find it. Skip this when using OIDC so the dummy doesn't shadow OIDC auth.
+  if (!useOIDC && !process.env.NODE_AUTH_TOKEN) {
     core.exportVariable("NODE_AUTH_TOKEN", "XXXXX-XXXXX-XXXXX-XXXXX");
   }
 }
@@ -338,8 +354,8 @@ const run = async () => {
   const alwaysAuth: string = core.getInput("always-auth") || "false";
   const mainBranchLatestTag: boolean = core.getBooleanInput("main-branch-latest-tag");
 
-  if (!process.env.NODE_AUTH_TOKEN) {
-    core.warning(`! warn: variable NODE_AUTH_TOKEN is not set`);
+  if (!process.env.NODE_AUTH_TOKEN && !process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+    core.warning(`! warn: variable NODE_AUTH_TOKEN is not set and OIDC is not available`);
   }
 
   if (process.env.NODE_AUTH_TOKEN || registryUrl) {


### PR DESCRIPTION
## Summary

Allows oddish-action to publish via npm Trusted Publishing (OIDC) instead of a long-lived `NODE_AUTH_TOKEN`. This is needed by repos migrating away from token-based publishing in response to npm's recent invalidation of granular tokens that bypass 2FA ([npmjs tweet](https://x.com/npmjs/status/2056960835030016286)).

## Problem

Today `writeRegistryToFile` always writes `_authToken=${NODE_AUTH_TOKEN}` to `.npmrc`, and when `NODE_AUTH_TOKEN` is absent it exports a dummy value (`XXXXX-XXXXX-XXXXX-XXXXX`). That dummy token gets sent to the registry as auth, which prevents npm from falling through to OIDC-based Trusted Publishing. Result: 401/403/404 from the registry even when the workflow has `permissions: id-token: write` and the package has a Trusted Publisher configured on npmjs.com.

## Change

Detect OIDC availability via the `ACTIONS_ID_TOKEN_REQUEST_URL` env var (GitHub Actions sets this only when the job grants `id-token: write`). When OIDC is available **and** the caller did not provide an explicit `NODE_AUTH_TOKEN`:

- Skip writing the `_authToken` line to `.npmrc` so npm uses OIDC for auth.
- Don't export the dummy `NODE_AUTH_TOKEN`.
- Don't warn about the missing `NODE_AUTH_TOKEN` (OIDC is the intended path).

Backwards compatible: existing flows that pass `NODE_AUTH_TOKEN` continue to work exactly as before. Existing flows without `NODE_AUTH_TOKEN` and without OIDC (e.g. local runs) also keep the prior behaviour (warning + dummy token).

## Files changed

- `oddish.ts` — source logic
- `dist/index.js` — regenerated bundle (`npm run build`)

## How to test

In a downstream repo (like `decentraland/marketplace`):

1. Configure `@your-scope/your-package` as a Trusted Publisher on npmjs.com (Provider: GitHub Actions, Repository: `org/repo`, Workflow: `your-publish.yaml`, Allowed actions: `npm publish`).
2. In the workflow, ensure `permissions: id-token: write` is set on the job.
3. Remove `NODE_AUTH_TOKEN` env from the publish step.
4. Use this branch:
   ```yaml
   uses: decentraland/oddish-action@feat/support-npm-trusted-publishing
   ```
5. Push to master. Expect oddish to log `using OIDC (npm Trusted Publishing) — skipping _authToken in .npmrc` and the publish to succeed without any token.

## References

- npm Trusted Publishers docs: https://docs.npmjs.com/trusted-publishers
- GitHub Actions OIDC docs: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect